### PR TITLE
Fixed SuperIO compatability on 1.6

### DIFF
--- a/Firmware/openxenium.vhd
+++ b/Firmware/openxenium.vhd
@@ -395,6 +395,7 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
                D0LEVEL <= '1';
             END IF;
             
+            CYCLE_TYPE <= IO_READ;
             LPC_CURRENT_STATE <= WAIT_START;
       END CASE;
    END IF;

--- a/Firmware/openxenium.vhd
+++ b/Firmware/openxenium.vhd
@@ -41,8 +41,8 @@
 --BANK1 (USER BIOS 512kB)    XXXX 0111     0 |0 |X    0x000000
 --BANK2 (USER BIOS 512kB)    XXXX 1000     0 |1 |X    0x080000
 --BANK1 (USER BIOS 1MB)      XXXX 1001     0 |X |X    0x000000
---RECOVERY (NOTE 1)          XXXX 1010     1 |1 |1    0x1C0000 
--- 
+--RECOVERY (NOTE 1)          XXXX 1010     1 |1 |1    0x1C0000
+--
 --
 --NOTE 1: The RECOVERY bank can also be actived by the physical switch on the Xenium. This forces bank ten (0b1010) on power up.
 --This bank also contains non-volatile storage of settings an EEPROM backup in the smaller sectors at the end of the flash memory.
@@ -58,15 +58,15 @@
 --X,SCK,CS,MOSI,BANK[3:0]
 --
 --**0xEF READ:**
---RECOV SWITCH POSITION (0=ACTIVE),X,MISO(Pin 1),MISO (Pin 4),BANK[3:0] 
+--RECOV SWITCH POSITION (0=ACTIVE),X,MISO(Pin 1),MISO (Pin 4),BANK[3:0]
 --
 --**0xEE (WRITE)**
 --X,X,X,X X,B,G,R (DEFAULT LED ON POWER UP IS RED)
 --
 --**0xEE (READ)**
 --Just returns 0x55 on a real xenium?
--- 
- 
+--
+
 LIBRARY IEEE;
 USE IEEE.STD_LOGIC_1164.ALL;
 USE IEEE.STD_LOGIC_UNSIGNED.ALL;
@@ -99,23 +99,23 @@ END openxenium;
 ARCHITECTURE Behavioral OF openxenium IS
 
    TYPE LPC_STATE_MACHINE IS (
-   WAIT_START, 
-   CYCTYPE_DIR, 
-   ADDRESS, 
-   WRITE_DATA,  
-   READ_DATA0, 
-   READ_DATA1, 
-   TAR1, 
-   TAR2, 
-   SYNCING, 
-   SYNC_COMPLETE, 
+   WAIT_START,
+   CYCTYPE_DIR,
+   ADDRESS,
+   WRITE_DATA,
+   READ_DATA0,
+   READ_DATA1,
+   TAR1,
+   TAR2,
+   SYNCING,
+   SYNC_COMPLETE,
    TAR_EXIT
    );
- 
+
    TYPE CYC_TYPE IS (
    IO_READ, --Default state
-   IO_WRITE, 
-   MEM_READ, 
+   IO_WRITE,
+   MEM_READ,
    MEM_WRITE
    );
 
@@ -126,22 +126,22 @@ ARCHITECTURE Behavioral OF openxenium IS
 
    --XENIUM IO REGISTERS. BITS MARKED 'X' HAVE AN UNKNOWN FUNCTION OR ARE UNUSED. NEEDS MORE RE.
    --Bit masks are all shown upper nibble first.
- 
+
    --IO WRITE/READ REGISTERS SIGNALS
    CONSTANT REG_00EE_READ : STD_LOGIC_VECTOR (7 DOWNTO 0) := "01010101"; -- Genuine Xenium
    SIGNAL REG_00EE_WRITE : STD_LOGIC_VECTOR (7 DOWNTO 0) := "00000001"; --X,X,X,X X,B,G,R. Red is default LED colour
    SIGNAL REG_00EF_WRITE : STD_LOGIC_VECTOR (7 DOWNTO 0) := "00000001"; --X,SCK,CS,MOSI, BANKCONTROL[3:0]. Bank 1 is default.
    SIGNAL REG_00EF_READ : STD_LOGIC_VECTOR (7 DOWNTO 0) := "01010101"; --Input signal
    SIGNAL READBUFFER : STD_LOGIC_VECTOR (7 DOWNTO 0); --I buffer Memory and IO reads to reduce pin to pin delay in CPLD which caused issues
- 
+
    --R/W SIGNAL FOR FLASH MEMORY
    SIGNAL sFLASH_DQ : STD_LOGIC_VECTOR (7 DOWNTO 0) := "ZZZZZZZZ";
- 
+
    --TSOPBOOT IS SET TO '1' WHEN YOU REQUEST TO BOOT FROM TSOP. THIS PREVENTS THE CPLD FROM DRIVING D0.
    --D0LEVEL is inverted and connected to the D0 output pad. This allows the CPLD to latch/release the D0/LFRAME signal.
    SIGNAL TSOPBOOT : STD_LOGIC := '0';
    SIGNAL D0LEVEL : STD_LOGIC := '0';
- 
+
    --GENERIC COUNTER USED TO TRACK ADDRESS AND SYNC COUNTERS.
    SIGNAL COUNT : INTEGER RANGE 0 TO 7;
 
@@ -165,12 +165,12 @@ BEGIN
               "1111" WHEN LPC_CURRENT_STATE = TAR2 ELSE
               "1111" WHEN LPC_CURRENT_STATE = TAR_EXIT ELSE
               READBUFFER(3 DOWNTO 0) WHEN LPC_CURRENT_STATE = READ_DATA0 ELSE --This has to be lower nibble first!
-              READBUFFER(7 DOWNTO 4) WHEN LPC_CURRENT_STATE = READ_DATA1 ELSE 
+              READBUFFER(7 DOWNTO 4) WHEN LPC_CURRENT_STATE = READ_DATA1 ELSE
               "ZZZZ";
 
    --FLASH_DQ is mapped to the data byte sent by the Xbox in MEM_WRITE mode, else its just an input
    FLASH_DQ <= sFLASH_DQ WHEN CYCLE_TYPE = MEM_WRITE ELSE "ZZZZZZZZ";
-   
+
    --Write Enable for Flash Memory Write (Active low)
    --Minimum pulse width 90ns.
    --Address is latched on the falling edge of WE.
@@ -200,8 +200,8 @@ BEGIN
    XENIUM_D0 <= '0' WHEN TSOPBOOT = '1' ELSE
                 '1' WHEN CYCLE_TYPE = MEM_READ ELSE
                 '1' WHEN CYCLE_TYPE = MEM_WRITE ELSE
-                NOT D0LEVEL; 
- 
+                NOT D0LEVEL;
+
    REG_00EF_READ <= XENIUM_RECOVERY & '0' & HEADER_4 & HEADER_1 & REG_00EF_WRITE(3 DOWNTO 0);
 
 PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
@@ -212,16 +212,16 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
       D0LEVEL <= TSOPBOOT;
       LPC_CURRENT_STATE <= WAIT_START;
 
-   ELSIF (rising_edge(LPC_CLK)) THEN 
+   ELSIF (rising_edge(LPC_CLK)) THEN
       CASE LPC_CURRENT_STATE IS
-         WHEN WAIT_START => 
+         WHEN WAIT_START =>
             IF LPC_LAD = "0000" AND TSOPBOOT = '0' THEN
                LPC_CURRENT_STATE <= CYCTYPE_DIR;
             END IF;
-         WHEN CYCTYPE_DIR => 
-         
+         WHEN CYCTYPE_DIR =>
+
             LPC_CURRENT_STATE <= ADDRESS;
-            
+
             IF LPC_LAD(3 DOWNTO 1) = "000" THEN
                CYCLE_TYPE <= IO_READ;
                COUNT <= 3;
@@ -237,9 +237,9 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
             ELSE
                LPC_CURRENT_STATE <= WAIT_START; -- Unsupported, reset state machine.
             END IF;
- 
+
          --ADDRESS GATHERING
-         WHEN ADDRESS => 
+         WHEN ADDRESS =>
 
             IF COUNT = 5 THEN
                LPC_ADDRESS(20) <= LPC_LAD(0);
@@ -251,50 +251,50 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
                   REG_00EF_WRITE(3 DOWNTO 0) <= "1010";
                END IF;
                CASE REG_00EF_WRITE(3 DOWNTO 0) IS
-                  WHEN "0001" => 
+                  WHEN "0001" =>
                      LPC_ADDRESS(20 DOWNTO 18) <= "110"; --256kb bank
-                  WHEN "0010" => 
+                  WHEN "0010" =>
                      LPC_ADDRESS(20 DOWNTO 19) <= "10"; --512kb bank
-                  WHEN "0011" => 
+                  WHEN "0011" =>
                      LPC_ADDRESS(20 DOWNTO 18) <= "000"; --256kb bank
-                  WHEN "0100" => 
+                  WHEN "0100" =>
                      LPC_ADDRESS(20 DOWNTO 18) <= "001"; --256kb bank
-                  WHEN "0101" => 
+                  WHEN "0101" =>
                      LPC_ADDRESS(20 DOWNTO 18) <= "010"; --256kb bank
-                  WHEN "0110" => 
+                  WHEN "0110" =>
                      LPC_ADDRESS(20 DOWNTO 18) <= "011"; --256kb bank
-                  WHEN "0111" => 
+                  WHEN "0111" =>
                      LPC_ADDRESS(20 DOWNTO 19) <= "00"; --512kb bank
-                  WHEN "1000" => 
+                  WHEN "1000" =>
                      LPC_ADDRESS(20 DOWNTO 19) <= "01"; --512kb bank
-                  WHEN "1001" => 
+                  WHEN "1001" =>
                      LPC_ADDRESS(20) <= '0'; --1mb bank
-                  WHEN "1010" => 
+                  WHEN "1010" =>
                      LPC_ADDRESS(20 DOWNTO 18) <= "111"; --256kb bank
-                  WHEN "0000" => 
+                  WHEN "0000" =>
                      --Bank zero will disable modchip and release D0 and reset state machine.
                      LPC_CURRENT_STATE <= WAIT_START;
                      TSOPBOOT <= '1';
-                  WHEN OTHERS => 
+                  WHEN OTHERS =>
                END CASE;
             ELSIF COUNT = 3 THEN
-               LPC_ADDRESS(15 DOWNTO 12) <= LPC_LAD; 
+               LPC_ADDRESS(15 DOWNTO 12) <= LPC_LAD;
             ELSIF COUNT = 2 THEN
                LPC_ADDRESS(11 DOWNTO 8) <= LPC_LAD;
             ELSIF COUNT = 1 THEN
                LPC_ADDRESS(7 DOWNTO 4) <= LPC_LAD;
             ELSIF COUNT = 0 THEN
                LPC_ADDRESS(3 DOWNTO 0) <= LPC_LAD;
-      
+
                LPC_CURRENT_STATE <= WAIT_START;
-               
+
                -- catch unsupported IO read/writes here before they modify LAD
                IF CYCLE_TYPE = MEM_READ THEN
                   LPC_CURRENT_STATE <= TAR1;
                ELSIF CYCLE_TYPE = MEM_WRITE THEN
                   LPC_CURRENT_STATE <= WRITE_DATA;
                ELSIF LPC_ADDRESS(7 DOWNTO 1) = x"77" THEN   -- check if supported Xenium register (EE or EF), the last bit is irrelevant
-               
+
                   IF CYCLE_TYPE = IO_READ THEN
                      LPC_CURRENT_STATE <= TAR1;
                   ELSIF CYCLE_TYPE = IO_WRITE THEN
@@ -302,26 +302,26 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
                   END IF;
 
                END IF;
-      
+
             END IF;
             COUNT <= COUNT - 1;
- 
+
          -- MEMORY OR IO WRITES. These all happen lower nibble first. (Refer to Intel LPC spec)
          -- HACK: abuses counter rollover from previous state
-         WHEN WRITE_DATA => 
-         
+         WHEN WRITE_DATA =>
+
             IF CYCLE_TYPE = MEM_WRITE THEN
-            
+
                IF COUNT = 7 THEN
                   sFLASH_DQ(3 DOWNTO 0) <= LPC_LAD;
                ELSE
                   sFLASH_DQ(7 DOWNTO 4) <= LPC_LAD;
                END IF;
-               
+
             ELSE
 
                -- it's already been confirmed this is a supported Xenium register in a previous state
-               -- so only a single bit needs to be checked to differentiate between the two 
+               -- so only a single bit needs to be checked to differentiate between the two
                IF LPC_ADDRESS(0) = '0' THEN
 
                   IF COUNT = 7 THEN
@@ -339,37 +339,37 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
                END IF;
 
             END IF;
-            
+
             IF COUNT = 6 THEN
                LPC_CURRENT_STATE <= TAR1;
             END IF;
-            COUNT <= COUNT - 1; 
+            COUNT <= COUNT - 1;
 
          --MEMORY OR IO READS
-         WHEN READ_DATA0 => 
+         WHEN READ_DATA0 =>
             LPC_CURRENT_STATE <= READ_DATA1;
-         WHEN READ_DATA1 => 
-            LPC_CURRENT_STATE <= TAR_EXIT; 
+         WHEN READ_DATA1 =>
+            LPC_CURRENT_STATE <= TAR_EXIT;
 
          --TURN BUS AROUND (HOST TO PERIPHERAL)
-         WHEN TAR1 => 
+         WHEN TAR1 =>
             LPC_CURRENT_STATE <= TAR2;
-         WHEN TAR2 => 
+         WHEN TAR2 =>
             LPC_CURRENT_STATE <= SYNCING;
             COUNT <= 6;
-            
+
          --SYNCING STAGE
          WHEN SYNCING =>
-            COUNT <= COUNT - 1;    
+            COUNT <= COUNT - 1;
             --Buffer IO reads during syncing. Helps output timings
             IF COUNT = 1 THEN
                IF CYCLE_TYPE = MEM_READ THEN
                   READBUFFER <= FLASH_DQ;
-                  
+
                ELSIF CYCLE_TYPE = IO_READ THEN
-               
+
                   -- it's already been confirmed this is a supported Xenium register in a previous state
-                  -- so only a single bit needs to be checked to differentiate between the two 
+                  -- so only a single bit needs to be checked to differentiate between the two
                   IF LPC_ADDRESS(0) = '0' THEN
                      READBUFFER <= REG_00EE_READ;
                   ELSE
@@ -379,22 +379,22 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
            ELSIF COUNT = 0 THEN
               LPC_CURRENT_STATE <= SYNC_COMPLETE;
            END IF;
-         WHEN SYNC_COMPLETE => 
+         WHEN SYNC_COMPLETE =>
             IF CYCLE_TYPE = MEM_READ OR CYCLE_TYPE = IO_READ THEN
                LPC_CURRENT_STATE <= READ_DATA0;
             ELSE
                LPC_CURRENT_STATE <= TAR_EXIT;
             END IF;
- 
+
          --TURN BUS AROUND (PERIPHERAL TO HOST)
-         WHEN TAR_EXIT => 
+         WHEN TAR_EXIT =>
             --D0 is held low until a few memory reads
             --This ensures it is booting from the modchip. Genuine Xenium arbitrarily
             --releases after the 5th read. This is always address 0x74
             IF LPC_ADDRESS(7 DOWNTO 0) = x"74" THEN
                D0LEVEL <= '1';
             END IF;
-            
+
             CYCLE_TYPE <= IO_READ;
             LPC_CURRENT_STATE <= WAIT_START;
       END CASE;


### PR DESCRIPTION
Fixes #22 

The issue leading to a failure of superio on a 1.6 when the d0 and lframe were connected had to do with the way the d0 signal was being held down. When in memory read and memory write cycles, d0 is held down. This makes sense as to stop the xyclops from acknowledging the requests. This also had an unexpected consequence of holding down d0 until an IO operation was done since the cycle type was never formally changed at the end. By adding "CYCLE_TYPE <= IO_READ;" to the end of the TAR_EXIT cycle, it allows for the D0LEVEL variable to control the signal after the memory read or write is done, and is not constantly being held down. 

My hypothesis is that the LFRAME signal was being held low for the start of the LPC cycle and once the OX realized it was an IO call and released the LFRAME line, it was already too late for the superio chip which didn't realize an lpc call had begun. 