### PR TITLE
Optimize LPC logic for modern chips. Fixes XBlast OS on 1.0 (#6)

### DIFF
--- a/Firmware/openxenium.vhd
+++ b/Firmware/openxenium.vhd
@@ -356,13 +356,13 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
             LPC_CURRENT_STATE <= TAR2;
          WHEN TAR2 =>
             LPC_CURRENT_STATE <= SYNCING;
-            COUNT <= 6;
+            COUNT <= 2;
 
          --SYNCING STAGE
          WHEN SYNCING =>
             COUNT <= COUNT - 1;
             --Buffer IO reads during syncing. Helps output timings
-            IF COUNT = 1 THEN
+            IF COUNT = 0 THEN
                IF CYCLE_TYPE = MEM_READ THEN
                   READBUFFER <= FLASH_DQ;
 
@@ -376,7 +376,6 @@ PROCESS (LPC_CLK, LPC_RST, TSOPBOOT) BEGIN
                      READBUFFER <= REG_00EF_READ;
                   END IF;
                END IF;
-           ELSIF COUNT = 0 THEN
               LPC_CURRENT_STATE <= SYNC_COMPLETE;
            END IF;
          WHEN SYNC_COMPLETE =>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ When used with XeniumOS the VHDL in this repo supports the following features:
   * Three outputs are connected to an RGB led (Or an external user added RGB led).
   * Reserved memory on the flash chip for non-volatile storage of an EEPROM backup and XeniumOS settings.
   * If you bridge the two recovery pins on power up, it will attempt to boot the XeniumOS recovery BIOS if available. This functions the same as a genuine Xenium modchip.
-  * I also simulate the LFRAME abort mechanism (*Ref Intel LPC Interface Spec Rev 1.1 Section 4.3.1.13*) so that this will work on a v1.6 Original Xbox. This aborts the LPC transaction to prevent the Xyclops responding to the MCPX LPC Memory Read requests during boot (and conflicting with an external LPC memory peripheral). This is generally accepted to be better than shorting LFRAME the ground constantly which some traditional *Modchips* do.
+  * I also simulate the LFRAME abort mechanism (*Ref Intel LPC Interface Spec Rev 1.1 Section 4.2.1.13*) so that this will work on a v1.6 Original Xbox. This aborts the LPC transaction to prevent the Xyclops responding to the MCPX LPC Memory Read requests during boot (and conflicting with an external LPC memory peripheral). This is generally accepted to be better than shorting LFRAME the ground constantly which some traditional *Modchips* do.
 
 ## XeniumOS BIOS
 **The recommended way to get a copy of XeniumOS is to take a backup of your own Xenium modchip using [Xenium-Tools](https://github.com/Ryzee119/Xenium-Tools/releases).** It is also possible to parse the v2.3.1 XeniumOS update files released by Team Xodus to extract the neccessary data; however this will not contain the factory programmed recovery sector, but otherwise works in the same way.


### PR DESCRIPTION
This PR reduces wait states for more concise read/write buffering, speeding up LPC transactions by ~130ns / byte. 

The change fixes the issue with XBlast OS not booting on 1.0 systems (#6) due to the strict timings of the P01 revision SMC. It probably will fix Cromwell too, but has not been tested.

In practice, this optimization speeds up every boot of the system by almost 120ms. This is because XeniumOS (compressed) is ~860kb which is copied over LPC to RAM every boot -- even with 'instant boot' enabled.

I have only tested this on an OX with the more modern S29AL016J70TFI010 (70ns) flash everyone is using nowadays, and cannot ensure compatibility with older chips. Flashing new bios' and launching them appears to function as expected, but I'd appreciate if others could double check my work as I'm not an expert at VHDL. 

Please note, this does *not* fix the issue where OX cannot be booted with mis-matched or bad chips. That issue must be fixed in XOS/flash, and I know how fussy everyone is about running modified Xenium firmwares so I'll leave that up to the community.

